### PR TITLE
When the Galil receives a simple CRLF, the response should be ":" not "?"

### DIFF
--- a/galil-simulator/src/main/scala/csw/proto/galil/simulator/GalilSimulator.scala
+++ b/galil-simulator/src/main/scala/csw/proto/galil/simulator/GalilSimulator.scala
@@ -89,6 +89,7 @@ case class GalilSimulator(host: String = "127.0.0.1", port: Int = 8888)
       val cmd = cmdString.take(2)
       if (cmdMap.contains(cmd)) genericCmd(cmdString)
       else cmd match { // basic commands are two upper case chars
+        case "" => formatReply(None) // pressing return will return a ":"
         case "BG" => formatReply(None)
         case "MO" => formatReply(None)
         case "NO" => formatReply(None) // no-op


### PR DESCRIPTION
This is my first pull request.  Let me know if there is anything else I need to do.