### PR TITLE
Galil 3 fix deploy dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,5 @@ lazy val `galil-deploy` = project
   .settings(defaultSettings: _*)
   .settings(libraryDependencies ++= Seq(
     `csw-framework`,
-    `galil-assembly-dep`,
-    `galil-hcd-dep`
   ))
+  .dependsOn(`galil-assembly`, `galil-hcd`)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,5 @@ object Dependencies {
   val playJson = "com.typesafe.play" %% "play-json" % PlayVersion
 
   val `csw-framework`  = "org.tmt" %% "csw-framework"  % CswVersion
-  val `galil-assembly-dep` = "org.tmt" %% "galil-assembly" % Version
-  val `galil-hcd-dep`      = "org.tmt" %% "galil-hcd"      % Version
 }
 


### PR DESCRIPTION
use dependsOn instead of ivy for galil hcd and assembly.